### PR TITLE
Hotfix for AE2 v12.8.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     minecraft("net.minecraftforge:forge:${minecraft_version}-${forge_version}")
 
     // We depend on many AE2 internals, such as using their basic cell drive, thus not using classifier = "api"
-    implementation(fg.deobf("appeng:appliedenergistics2:${ae2_version}"))
+    implementation(fg.deobf("appeng:appliedenergistics2-forge:${ae2_version}"))
 
     compileOnly(fg.deobf("mekanism:Mekanism:${minecraft_version}-${mekanism_version}:api"))
     runtimeOnly(fg.deobf("mekanism:Mekanism:${minecraft_version}-${mekanism_version}:all"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 minecraft_version=1.19.2
-forge_version=43.1.16
-ae2_version=12.2.0-beta
+forge_version=43.1.27
+ae2_version=12.8.4
 mekanism_version=10.3.3.470
 jei_version=11.3.0.260
 jade_id=3960379

--- a/src/main/java/me/ramidzkh/mekae2/AMItems.java
+++ b/src/main/java/me/ramidzkh/mekae2/AMItems.java
@@ -15,12 +15,11 @@ import me.ramidzkh.mekae2.item.ChemicalPortableCellItem;
 import me.ramidzkh.mekae2.item.ChemicalStorageCell;
 
 import appeng.api.parts.PartModels;
-import appeng.core.definitions.AEItems;
 import appeng.items.materials.MaterialItem;
 import appeng.items.parts.PartItem;
 import appeng.items.parts.PartModelsHelper;
 import appeng.items.storage.CreativeCellItem;
-import appeng.items.tools.powered.PortableCellItem;
+import appeng.items.storage.StorageTier;
 
 public class AMItems {
 
@@ -53,38 +52,34 @@ public class AMItems {
             () -> new CreativeCellItem(properties().stacksTo(1).rarity(Rarity.EPIC)));
 
     public static final RegistryObject<Item> CHEMICAL_CELL_1K = ITEMS.register("chemical_storage_cell_1k",
-            () -> new ChemicalStorageCell(properties().stacksTo(1), AEItems.CELL_COMPONENT_1K,
-                    CHEMICAL_CELL_HOUSING.get(), 0.5f, 1, 8, 5));
+            () -> new ChemicalStorageCell(properties().stacksTo(1), StorageTier.SIZE_1K, CHEMICAL_CELL_HOUSING.get()));
     public static final RegistryObject<Item> CHEMICAL_CELL_4K = ITEMS.register("chemical_storage_cell_4k",
-            () -> new ChemicalStorageCell(properties().stacksTo(1), AEItems.CELL_COMPONENT_4K,
-                    CHEMICAL_CELL_HOUSING.get(), 1.0f, 4, 32, 5));
+            () -> new ChemicalStorageCell(properties().stacksTo(1), StorageTier.SIZE_4K, CHEMICAL_CELL_HOUSING.get()));
     public static final RegistryObject<Item> CHEMICAL_CELL_16K = ITEMS.register("chemical_storage_cell_16k",
-            () -> new ChemicalStorageCell(properties().stacksTo(1), AEItems.CELL_COMPONENT_16K,
-                    CHEMICAL_CELL_HOUSING.get(), 1.5f, 16, 128, 5));
+            () -> new ChemicalStorageCell(properties().stacksTo(1), StorageTier.SIZE_16K, CHEMICAL_CELL_HOUSING.get()));
     public static final RegistryObject<Item> CHEMICAL_CELL_64K = ITEMS.register("chemical_storage_cell_64k",
-            () -> new ChemicalStorageCell(properties().stacksTo(1), AEItems.CELL_COMPONENT_64K,
-                    CHEMICAL_CELL_HOUSING.get(), 2.0f, 64, 512, 5));
+            () -> new ChemicalStorageCell(properties().stacksTo(1), StorageTier.SIZE_64K, CHEMICAL_CELL_HOUSING.get()));
     public static final RegistryObject<Item> CHEMICAL_CELL_256K = ITEMS.register("chemical_storage_cell_256k",
-            () -> new ChemicalStorageCell(properties().stacksTo(1), AEItems.CELL_COMPONENT_256K,
-                    CHEMICAL_CELL_HOUSING.get(), 2.5f, 256, 2048, 5));
+            () -> new ChemicalStorageCell(properties().stacksTo(1), StorageTier.SIZE_256K,
+                    CHEMICAL_CELL_HOUSING.get()));
 
     public static final RegistryObject<Item> PORTABLE_CHEMICAL_CELL_1K = ITEMS.register(
             "portable_chemical_storage_cell_1k", () -> new ChemicalPortableCellItem(AMMenus.PORTABLE_CHEMICAL_CELL_TYPE,
-                    PortableCellItem.SIZE_1K, properties().stacksTo(1)));
+                    StorageTier.SIZE_1K, properties().stacksTo(1)));
     public static final RegistryObject<Item> PORTABLE_CHEMICAL_CELL_4K = ITEMS.register(
             "portable_chemical_storage_cell_4k", () -> new ChemicalPortableCellItem(AMMenus.PORTABLE_CHEMICAL_CELL_TYPE,
-                    PortableCellItem.SIZE_4K, properties().stacksTo(1)));
+                    StorageTier.SIZE_4K, properties().stacksTo(1)));
     public static final RegistryObject<Item> PORTABLE_CHEMICAL_CELL_16K = ITEMS.register(
             "portable_chemical_storage_cell_16k",
-            () -> new ChemicalPortableCellItem(AMMenus.PORTABLE_CHEMICAL_CELL_TYPE, PortableCellItem.SIZE_16K,
+            () -> new ChemicalPortableCellItem(AMMenus.PORTABLE_CHEMICAL_CELL_TYPE, StorageTier.SIZE_16K,
                     properties().stacksTo(1)));
     public static final RegistryObject<Item> PORTABLE_CHEMICAL_CELL_64K = ITEMS.register(
             "portable_chemical_storage_cell_64k",
-            () -> new ChemicalPortableCellItem(AMMenus.PORTABLE_CHEMICAL_CELL_TYPE, PortableCellItem.SIZE_64K,
+            () -> new ChemicalPortableCellItem(AMMenus.PORTABLE_CHEMICAL_CELL_TYPE, StorageTier.SIZE_64K,
                     properties().stacksTo(1)));
     public static final RegistryObject<Item> PORTABLE_CHEMICAL_CELL_256K = ITEMS.register(
             "portable_chemical_storage_cell_256k",
-            () -> new ChemicalPortableCellItem(AMMenus.PORTABLE_CHEMICAL_CELL_TYPE, PortableCellItem.SIZE_256K,
+            () -> new ChemicalPortableCellItem(AMMenus.PORTABLE_CHEMICAL_CELL_TYPE, StorageTier.SIZE_256K,
                     properties().stacksTo(1)));
 
     public static final RegistryObject<PartItem<ChemicalP2PTunnelPart>> CHEMICAL_P2P_TUNNEL = Util.make(() -> {

--- a/src/main/java/me/ramidzkh/mekae2/item/ChemicalPortableCellItem.java
+++ b/src/main/java/me/ramidzkh/mekae2/item/ChemicalPortableCellItem.java
@@ -8,6 +8,7 @@ import me.ramidzkh.mekae2.ae2.MekanismKeyType;
 import mekanism.api.chemical.attribute.ChemicalAttributeValidator;
 
 import appeng.api.stacks.AEKey;
+import appeng.items.storage.StorageTier;
 import appeng.items.tools.powered.PortableCellItem;
 
 public class ChemicalPortableCellItem extends PortableCellItem {

--- a/src/main/java/me/ramidzkh/mekae2/item/ChemicalStorageCell.java
+++ b/src/main/java/me/ramidzkh/mekae2/item/ChemicalStorageCell.java
@@ -9,12 +9,13 @@ import mekanism.api.chemical.attribute.ChemicalAttributeValidator;
 
 import appeng.api.stacks.AEKey;
 import appeng.items.storage.BasicStorageCell;
+import appeng.items.storage.StorageTier;
 
 public class ChemicalStorageCell extends BasicStorageCell {
 
-    public ChemicalStorageCell(Properties properties, ItemLike coreItem, ItemLike housingItem, double idleDrain,
-            int kilobytes, int bytesPerType, int totalTypes) {
-        super(properties, coreItem, housingItem, idleDrain, kilobytes, bytesPerType, totalTypes, MekanismKeyType.TYPE);
+    public ChemicalStorageCell(Properties properties, StorageTier tier, ItemLike housingItem) {
+        super(properties, tier.componentSupplier().get(), housingItem, tier.idleDrain(), tier.bytes() / 1024,
+                tier.bytes() / 128, 5, MekanismKeyType.TYPE);
     }
 
     @Override

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader = "javafml"
-loaderVersion = "[39,)"
+loaderVersion = "[43,)"
 #updateJSONURL=""
 issueTrackerURL = "https://github.com/AppliedEnergistics/Applied-Mekanistics/issues"
 displayURL = "https://github.com/AppliedEnergistics/Applied-Mekanistics#readme"
@@ -25,7 +25,7 @@ side = "BOTH"
 [[dependencies.appmek]]
 modId = "ae2"
 mandatory = false
-versionRange = "[12.0.0,13.0.0)"
+versionRange = "[12.8.4,13.0.0)"
 ordering = "AFTER"
 side = "BOTH"
 


### PR DESCRIPTION
Mainly to make use of the general `StorageTier` record since it's been moved out from the portable cell class.