### PR TITLE
Update Jade plugin to directly check for interface and pattern provider instances

### DIFF
--- a/src/main/java/me/ramidzkh/mekae2/integration/jade/AMJadePlugin.java
+++ b/src/main/java/me/ramidzkh/mekae2/integration/jade/AMJadePlugin.java
@@ -21,13 +21,12 @@ public class AMJadePlugin implements IWailaPlugin {
     @Override
     public void registerClient(IWailaClientRegistration registration) {
         registration.addTooltipCollectedCallback((tooltip, accessor) -> {
-            if (!(accessor.getTarget() instanceof InterfaceLogicHost
-                    || accessor.getTarget() instanceof PatternProviderLogicHost)) {
-                return;
-            }
+            var target = accessor.getTarget();
 
-            for (var loc : CHEMICALS) {
-                tooltip.remove(loc);
+            if (target instanceof InterfaceLogicHost || target instanceof PatternProviderLogicHost) {
+                for (var loc : CHEMICALS) {
+                    tooltip.remove(loc);
+                }
             }
         });
     }

--- a/src/main/java/me/ramidzkh/mekae2/integration/jade/AMJadePlugin.java
+++ b/src/main/java/me/ramidzkh/mekae2/integration/jade/AMJadePlugin.java
@@ -21,15 +21,11 @@ public class AMJadePlugin implements IWailaPlugin {
     @Override
     public void registerClient(IWailaClientRegistration registration) {
         registration.addTooltipCollectedCallback((tooltip, accessor) -> {
-            // This is ugly, but nothing else worked perfectly due to Jade using old server data for new blocks.
-            // TODO: check if this is still needed in 1.19+
-            for (var loc : CHEMICALS) {
-                if (tooltip.get(loc).size() != 9) {
-                    return;
-                }
+            if (!(accessor.getTarget() instanceof InterfaceLogicHost
+                    || accessor.getTarget() instanceof PatternProviderLogicHost)) {
+                return;
             }
 
-            // If we have 9 of each 4, remove them.
             for (var loc : CHEMICALS) {
                 tooltip.remove(loc);
             }

--- a/src/main/java/me/ramidzkh/mekae2/integration/jade/AMJadePlugin.java
+++ b/src/main/java/me/ramidzkh/mekae2/integration/jade/AMJadePlugin.java
@@ -6,6 +6,9 @@ import snownee.jade.api.IWailaClientRegistration;
 import snownee.jade.api.IWailaPlugin;
 import snownee.jade.api.WailaPlugin;
 
+import appeng.helpers.InterfaceLogicHost;
+import appeng.helpers.patternprovider.PatternProviderLogicHost;
+
 /**
  * Plugin to remove the mekanism-added chemical handler lines for interfaces and pattern providers.
  */


### PR DESCRIPTION
Seems like it's no longer necessary to do a hard-coded check for the amount of chemical handler tooltips, so this new check should now also apply for other extended implementations of interfaces and pattern providers such as ExtendedAE and MEGA.