### PR TITLE
Add support for Chemicals to ae2jeiintegration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,15 @@ repositories {
     }
 
     maven {
+        name = "Jared maven"
+        url = uri("https://maven.blamejared.com")
+
+        content {
+            includeGroup("mezz.jei")
+        }
+    }
+
+    maven {
         name = "Local"
         url = file("libs").toURI()
     }
@@ -52,7 +61,17 @@ dependencies {
     compileOnly("mekanism:Mekanism:${minecraft_version}-${mekanism_version}:api")
     runtimeOnly("mekanism:Mekanism:${minecraft_version}-${mekanism_version}:all")
 
-    implementation("dev.emi:emi-neoforge:${project.emi_version}")
+    if (project.runtime_itemlist_mod == "emi") {
+        implementation("dev.emi:emi-neoforge:${project.emi_version}")
+        compileOnly("mezz.jei:jei-${project.minecraft_version}-neoforge:${project.jei_version}")
+        compileOnly("curse.maven:ae2-jei-integration-1074338:${jei_ae2_integration_id}")
+    } else if (project.runtime_itemlist_mod == "jei") {
+        compileOnly("dev.emi:emi-neoforge:${project.emi_version}")
+        implementation("mezz.jei:jei-${project.minecraft_version}-neoforge:${project.jei_version}")
+        implementation("curse.maven:ae2-jei-integration-1074338:${jei_ae2_integration_id}")
+    } else {
+        throw new GradleException("Invalid runtime_itemlist_mod value: " + project.runtime_itemlist_mod)
+    }
 
     compileOnly("curse.maven:jade-324717:${jade_id}")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,16 @@
 minecraft_version=1.21.1
 neoforge_version=21.1.22
-ae2_version=19.0.20-beta
+ae2_version=19.0.22-beta
 mekanism_version=10.7.0.55
 emi_version=1.1.12+1.21
 jade_id=5427817
+jei_version=19.9.1.124
+jei_ae2_integration_id=5663887
+
+# Dev runtime options
+## Set to "jei" or "emi" to pick which tooltip mod gets picked at runtime
+## for the dev environment.
+runtime_itemlist_mod=emi
 
 loader_version_range=[1,)
 neo_version_range=[21.0,)

--- a/src/main/java/me/ramidzkh/mekae2/integration/jei/AE2JeiIntegrationHelper.java
+++ b/src/main/java/me/ramidzkh/mekae2/integration/jei/AE2JeiIntegrationHelper.java
@@ -1,0 +1,9 @@
+package me.ramidzkh.mekae2.integration.jei;
+
+import tamaized.ae2jeiintegration.api.integrations.jei.IngredientConverters;
+
+public class AE2JeiIntegrationHelper {
+	public static void register() {
+		IngredientConverters.register(new ChemicalIngredientConverter());
+	}
+}

--- a/src/main/java/me/ramidzkh/mekae2/integration/jei/AE2JeiIntegrationHelper.java
+++ b/src/main/java/me/ramidzkh/mekae2/integration/jei/AE2JeiIntegrationHelper.java
@@ -3,7 +3,7 @@ package me.ramidzkh.mekae2.integration.jei;
 import tamaized.ae2jeiintegration.api.integrations.jei.IngredientConverters;
 
 public class AE2JeiIntegrationHelper {
-	public static void register() {
-		IngredientConverters.register(new ChemicalIngredientConverter());
-	}
+    public static void register() {
+        IngredientConverters.register(new ChemicalIngredientConverter());
+    }
 }

--- a/src/main/java/me/ramidzkh/mekae2/integration/jei/AMJeiPlugin.java
+++ b/src/main/java/me/ramidzkh/mekae2/integration/jei/AMJeiPlugin.java
@@ -1,0 +1,30 @@
+package me.ramidzkh.mekae2.integration.jei;
+
+import me.ramidzkh.mekae2.AppliedMekanistics;
+import mezz.jei.api.IModPlugin;
+import mezz.jei.api.JeiPlugin;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.fml.ModList;
+import net.neoforged.fml.loading.LoadingModList;
+import net.neoforged.fml.loading.moddiscovery.ModInfo;
+
+@JeiPlugin
+public class AMJeiPlugin implements IModPlugin {
+	@Override
+	public ResourceLocation getPluginUid() {
+		return ResourceLocation.fromNamespaceAndPath(AppliedMekanistics.ID, "jei_plugin");
+	}
+
+	public AMJeiPlugin() {
+		if (isModLoaded("ae2jeiintegration")) {
+			AE2JeiIntegrationHelper.register();
+		}
+	}
+
+	private static boolean isModLoaded(String modId) {
+		if (ModList.get() == null) {
+			return LoadingModList.get().getMods().stream().map(ModInfo::getModId).anyMatch(modId::equals);
+		}
+		return ModList.get().isLoaded(modId);
+	}
+}

--- a/src/main/java/me/ramidzkh/mekae2/integration/jei/AMJeiPlugin.java
+++ b/src/main/java/me/ramidzkh/mekae2/integration/jei/AMJeiPlugin.java
@@ -1,30 +1,31 @@
 package me.ramidzkh.mekae2.integration.jei;
 
-import me.ramidzkh.mekae2.AppliedMekanistics;
-import mezz.jei.api.IModPlugin;
-import mezz.jei.api.JeiPlugin;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.fml.ModList;
 import net.neoforged.fml.loading.LoadingModList;
 import net.neoforged.fml.loading.moddiscovery.ModInfo;
 
+import me.ramidzkh.mekae2.AppliedMekanistics;
+import mezz.jei.api.IModPlugin;
+import mezz.jei.api.JeiPlugin;
+
 @JeiPlugin
 public class AMJeiPlugin implements IModPlugin {
-	@Override
-	public ResourceLocation getPluginUid() {
-		return ResourceLocation.fromNamespaceAndPath(AppliedMekanistics.ID, "jei_plugin");
-	}
+    @Override
+    public ResourceLocation getPluginUid() {
+        return ResourceLocation.fromNamespaceAndPath(AppliedMekanistics.ID, "jei_plugin");
+    }
 
-	public AMJeiPlugin() {
-		if (isModLoaded("ae2jeiintegration")) {
-			AE2JeiIntegrationHelper.register();
-		}
-	}
+    public AMJeiPlugin() {
+        if (isModLoaded("ae2jeiintegration")) {
+            AE2JeiIntegrationHelper.register();
+        }
+    }
 
-	private static boolean isModLoaded(String modId) {
-		if (ModList.get() == null) {
-			return LoadingModList.get().getMods().stream().map(ModInfo::getModId).anyMatch(modId::equals);
-		}
-		return ModList.get().isLoaded(modId);
-	}
+    private static boolean isModLoaded(String modId) {
+        if (ModList.get() == null) {
+            return LoadingModList.get().getMods().stream().map(ModInfo::getModId).anyMatch(modId::equals);
+        }
+        return ModList.get().isLoaded(modId);
+    }
 }

--- a/src/main/java/me/ramidzkh/mekae2/integration/jei/ChemicalIngredientConverter.java
+++ b/src/main/java/me/ramidzkh/mekae2/integration/jei/ChemicalIngredientConverter.java
@@ -1,43 +1,45 @@
 package me.ramidzkh.mekae2.integration.jei;
 
-import appeng.api.stacks.GenericStack;
+import org.jetbrains.annotations.Nullable;
+
 import me.ramidzkh.mekae2.ae2.MekanismKey;
 import mekanism.api.IMekanismAccess;
 import mekanism.api.chemical.ChemicalStack;
 import mekanism.api.integration.jei.IMekanismJEIHelper;
 import mezz.jei.api.ingredients.IIngredientHelper;
 import mezz.jei.api.ingredients.IIngredientType;
-import org.jetbrains.annotations.Nullable;
 import tamaized.ae2jeiintegration.api.integrations.jei.IngredientConverter;
 
+import appeng.api.stacks.GenericStack;
+
 public class ChemicalIngredientConverter implements IngredientConverter<ChemicalStack> {
-	private final IIngredientType<ChemicalStack> ingredientType;
+    private final IIngredientType<ChemicalStack> ingredientType;
 
-	public ChemicalIngredientConverter() {
-		IMekanismJEIHelper mekJeiHelper = IMekanismAccess.INSTANCE.jeiHelper();
-		IIngredientHelper<ChemicalStack> chemicalStackHelper = mekJeiHelper.getChemicalStackHelper();
-		this.ingredientType = chemicalStackHelper.getIngredientType();
-	}
+    public ChemicalIngredientConverter() {
+        IMekanismJEIHelper mekJeiHelper = IMekanismAccess.INSTANCE.jeiHelper();
+        IIngredientHelper<ChemicalStack> chemicalStackHelper = mekJeiHelper.getChemicalStackHelper();
+        this.ingredientType = chemicalStackHelper.getIngredientType();
+    }
 
-	@Override
-	public IIngredientType<ChemicalStack> getIngredientType() {
-		return ingredientType;
-	}
+    @Override
+    public IIngredientType<ChemicalStack> getIngredientType() {
+        return ingredientType;
+    }
 
-	@Override
-	public @Nullable ChemicalStack getIngredientFromStack(GenericStack genericStack) {
-		if (genericStack.what() instanceof MekanismKey key) {
-			return key.withAmount(genericStack.amount());
-		}
-		return null;
-	}
+    @Override
+    public @Nullable ChemicalStack getIngredientFromStack(GenericStack genericStack) {
+        if (genericStack.what() instanceof MekanismKey key) {
+            return key.withAmount(genericStack.amount());
+        }
+        return null;
+    }
 
-	@Override
-	public @Nullable GenericStack getStackFromIngredient(ChemicalStack chemicalStack) {
-		var what = MekanismKey.of(chemicalStack);
-		if (what == null) {
-			return null;
-		}
-		return new GenericStack(what, chemicalStack.getAmount());
-	}
+    @Override
+    public @Nullable GenericStack getStackFromIngredient(ChemicalStack chemicalStack) {
+        var what = MekanismKey.of(chemicalStack);
+        if (what == null) {
+            return null;
+        }
+        return new GenericStack(what, chemicalStack.getAmount());
+    }
 }

--- a/src/main/java/me/ramidzkh/mekae2/integration/jei/ChemicalIngredientConverter.java
+++ b/src/main/java/me/ramidzkh/mekae2/integration/jei/ChemicalIngredientConverter.java
@@ -1,0 +1,43 @@
+package me.ramidzkh.mekae2.integration.jei;
+
+import appeng.api.stacks.GenericStack;
+import me.ramidzkh.mekae2.ae2.MekanismKey;
+import mekanism.api.IMekanismAccess;
+import mekanism.api.chemical.ChemicalStack;
+import mekanism.api.integration.jei.IMekanismJEIHelper;
+import mezz.jei.api.ingredients.IIngredientHelper;
+import mezz.jei.api.ingredients.IIngredientType;
+import org.jetbrains.annotations.Nullable;
+import tamaized.ae2jeiintegration.api.integrations.jei.IngredientConverter;
+
+public class ChemicalIngredientConverter implements IngredientConverter<ChemicalStack> {
+	private final IIngredientType<ChemicalStack> ingredientType;
+
+	public ChemicalIngredientConverter() {
+		IMekanismJEIHelper mekJeiHelper = IMekanismAccess.INSTANCE.jeiHelper();
+		IIngredientHelper<ChemicalStack> chemicalStackHelper = mekJeiHelper.getChemicalStackHelper();
+		this.ingredientType = chemicalStackHelper.getIngredientType();
+	}
+
+	@Override
+	public IIngredientType<ChemicalStack> getIngredientType() {
+		return ingredientType;
+	}
+
+	@Override
+	public @Nullable ChemicalStack getIngredientFromStack(GenericStack genericStack) {
+		if (genericStack.what() instanceof MekanismKey key) {
+			return key.withAmount(genericStack.amount());
+		}
+		return null;
+	}
+
+	@Override
+	public @Nullable GenericStack getStackFromIngredient(ChemicalStack chemicalStack) {
+		var what = MekanismKey.of(chemicalStack);
+		if (what == null) {
+			return null;
+		}
+		return new GenericStack(what, chemicalStack.getAmount());
+	}
+}

--- a/src/main/java/me/ramidzkh/mekae2/integration/jei/package-info.java
+++ b/src/main/java/me/ramidzkh/mekae2/integration/jei/package-info.java
@@ -2,6 +2,6 @@
 @MethodsReturnNonnullByDefault
 package me.ramidzkh.mekae2.integration.jei;
 
-import net.minecraft.MethodsReturnNonnullByDefault;
-
 import javax.annotation.ParametersAreNonnullByDefault;
+
+import net.minecraft.MethodsReturnNonnullByDefault;

--- a/src/main/java/me/ramidzkh/mekae2/integration/jei/package-info.java
+++ b/src/main/java/me/ramidzkh/mekae2/integration/jei/package-info.java
@@ -1,0 +1,7 @@
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+package me.ramidzkh.mekae2.integration.jei;
+
+import net.minecraft.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
This allows using Mekanism Chemicals for Patterns and Filters with JEI when using the [ae2jeiintegration mod](https://github.com/Tamaized/AE2-JEI-Integration).

This does not re-integration EMI and JEI together, they are handled separately.