### PR TITLE
Fix JEI bookmarking Mekanism chemicals from AE2 filters

### DIFF
--- a/src/main/java/me/ramidzkh/mekae2/integration/jei/ChemicalIngredientConverter.java
+++ b/src/main/java/me/ramidzkh/mekae2/integration/jei/ChemicalIngredientConverter.java
@@ -29,7 +29,7 @@ public class ChemicalIngredientConverter implements IngredientConverter<Chemical
     @Override
     public @Nullable ChemicalStack getIngredientFromStack(GenericStack genericStack) {
         if (genericStack.what() instanceof MekanismKey key) {
-            return key.withAmount(genericStack.amount());
+            return key.withAmount(Math.max(1, genericStack.amount()));
         }
         return null;
     }


### PR DESCRIPTION
When trying to bookmark chemicals from AE2 filters, it results in a "generic stack" being saved to JEI because this mod isn't able to create a valid bookmark from the filter ingredient.
That is because the AE2 filter uses an ingredient with size 0.

This fixes the issue by making sure valid ingredients are created in this situation, with a size of at least 1.